### PR TITLE
refactor db adapter

### DIFF
--- a/service/controllers/usersController.go
+++ b/service/controllers/usersController.go
@@ -13,7 +13,7 @@ import (
 func AllUsers(c *gin.Context) {
 	var users []models.User
 	DBInstance := c.MustGet("db").(databases.IDBAdapter)
-	DBInstance.Find(c, &users)
+	DBInstance.Find(&users)
 
 	c.JSON(http.StatusOK, gin.H{"data": users})
 }
@@ -25,7 +25,7 @@ func FindUser(c *gin.Context) {
 	var user []models.User
 	DBInstance := c.MustGet("db").(databases.IDBAdapter)
 
-	DBInstance.Find(c, &user, "id = ?", c.Param("id"))
+	DBInstance.Find(&user, "id = ?", c.Param("id"))
 	if len(user) == 0 {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Record not found!"})
 		return
@@ -48,7 +48,7 @@ func CreateUser(c *gin.Context) {
 	// Create user
 	user := models.User{Name: input.Name, Email: input.Email, Phone: input.Phone}
 	DBInstance := c.MustGet("db").(databases.IDBAdapter)
-	DBInstance.Create(c, &user)
+	DBInstance.Create(&user)
 
 	c.JSON(http.StatusOK, gin.H{"data": user})
 }
@@ -60,7 +60,7 @@ func UpdateUser(c *gin.Context) {
 	var user []models.User
 	DBInstance := c.MustGet("db").(databases.IDBAdapter)
 
-	DBInstance.Find(c, &user, "id = ?", c.Param("id"))
+	DBInstance.Find(&user, "id = ?", c.Param("id"))
 	if len(user) == 0 {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Record not found!"})
 		return
@@ -74,7 +74,7 @@ func UpdateUser(c *gin.Context) {
 		return
 	}
 
-	DBInstance.Update(c, &user[0], models.User{Name: input.Name, Email: input.Email, Phone: input.Phone})
+	DBInstance.Update(&user[0], models.User{Name: input.Name, Email: input.Email, Phone: input.Phone})
 
 	c.JSON(http.StatusOK, gin.H{"data": user})
 }
@@ -86,13 +86,13 @@ func DeleteUser(c *gin.Context) {
 	var user []models.User
 	DBInstance := c.MustGet("db").(databases.IDBAdapter)
 
-	DBInstance.Find(c, &user, "id = ?", c.Param("id"))
+	DBInstance.Find(&user, "id = ?", c.Param("id"))
 	if len(user) == 0 {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Record not found!"})
 		return
 	}
 
-	DBInstance.Delete(c, &user)
+	DBInstance.Delete(&user)
 
 	c.JSON(http.StatusOK, gin.H{"data": true})
 }

--- a/service/databases/IDBAdapter.go
+++ b/service/databases/IDBAdapter.go
@@ -1,14 +1,10 @@
 package databases
 
-import (
-	"github.com/gin-gonic/gin"
-)
-
 type IDBAdapter interface {
-	Connect(c *gin.Context) error
-	Close(c *gin.Context) error
-	Create(c *gin.Context, model interface{}) error
-	Find(c *gin.Context, models interface{}, conds ...interface{}) error
-	Update(c *gin.Context, model interface{}, values interface{}) error
-	Delete(c *gin.Context, model interface{}) error
+	Connect() error
+	Close() error
+	Create(model interface{}) error
+	Find(models interface{}, conds ...interface{}) error
+	Update(model interface{}, values interface{}) error
+	Delete(model interface{}) error
 }

--- a/service/databases/SQLAdapter.go
+++ b/service/databases/SQLAdapter.go
@@ -3,7 +3,6 @@ package databases
 import (
 	"qgen/challange/models"
 
-	"github.com/gin-gonic/gin"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
@@ -17,7 +16,7 @@ func NewSQLAdapter() *SQLDB {
 }
 
 // Connect to the database
-func (d *SQLDB) Connect(c *gin.Context) error {
+func (d *SQLDB) Connect() error {
 	database, err := gorm.Open(sqlite.Open("test.db"), &gorm.Config{})
 
 	if err != nil {
@@ -25,36 +24,31 @@ func (d *SQLDB) Connect(c *gin.Context) error {
 	}
 
 	database.AutoMigrate(&models.User{})
-	sqlDB := &SQLDB{db: database}
-	c.Set("db", sqlDB)
+	d.db = database
 	return nil
 }
 
 // Close the database connection
-func (d *SQLDB) Close(c *gin.Context) error {
+func (d *SQLDB) Close() error {
 	return nil
 }
 
 // Create a new record in the database
-func (d *SQLDB) Create(c *gin.Context, model interface{}) error {
-	dba := c.MustGet("db").(*SQLDB)
-	return dba.db.Create(model).Error
+func (d *SQLDB) Create(model interface{}) error {
+	return d.db.Create(model).Error
 }
 
 // Read a record from the database
-func (d *SQLDB) Find(c *gin.Context, models_list interface{}, conds ...interface{}) error {
-	dba := c.MustGet("db").(*SQLDB)
-	return dba.db.Find(models_list, conds).Error
+func (d *SQLDB) Find(models_list interface{}, conds ...interface{}) error {
+	return d.db.Find(models_list, conds).Error
 }
 
 // Update a record in the database
-func (d *SQLDB) Update(c *gin.Context, model interface{}, values interface{}) error {
-	dba := c.MustGet("db").(*SQLDB)
-	return dba.db.Model(model).Updates(values).Error
+func (d *SQLDB) Update(model interface{}, values interface{}) error {
+	return d.db.Model(model).Updates(values).Error
 }
 
 // Delete a record from the database
-func (d *SQLDB) Delete(c *gin.Context, model interface{}) error {
-	dba := c.MustGet("db").(*SQLDB)
-	return dba.db.Delete(model).Error
+func (d *SQLDB) Delete(model interface{}) error {
+	return d.db.Delete(model).Error
 }

--- a/service/middlewares/middlewares.go
+++ b/service/middlewares/middlewares.go
@@ -25,8 +25,9 @@ func CORSMiddleware() gin.HandlerFunc {
 
 func DBMiddleware(d databases.IDBAdapter) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		d.Connect(c)
-		defer d.Close(c)
+		d.Connect()
+		c.Set("db", d)
+		defer d.Close()
 		c.Next()
 	}
 }


### PR DESCRIPTION
refactor database adapter
There is no reason to pass the `*gin.context` to the DB adapter.